### PR TITLE
Allow ability to control hide

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -50,6 +50,8 @@ let propTypes = {
   startAccessor: accessor.isRequired,
   endAccessor: accessor.isRequired,
 
+  handleOnHideOverlay: PropTypes.func,
+
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
   longPressThreshold: PropTypes.number,
@@ -103,6 +105,8 @@ class MonthView extends React.Component {
     let running
 
     if (this.state.needLimitMeasure) this.measureRowLimit(this.props)
+
+    this.onHideOverlay = this.onHideOverlay.bind(this)
 
     window.addEventListener(
       'resize',
@@ -260,9 +264,13 @@ class MonthView extends React.Component {
     ))
   }
 
+  onHideOverlay() {
+    this.setState({ overlay: null })
+  }
+
   renderOverlay() {
     let overlay = (this.state && this.state.overlay) || {}
-    let { components } = this.props
+    let { components, handleOnHideOverlay } = this.props
 
     const PopupComponent = components.popup || Popup
 
@@ -272,7 +280,14 @@ class MonthView extends React.Component {
         placement="bottom"
         container={this}
         show={!!overlay.position}
-        onHide={() => this.setState({ overlay: null })}
+        onHide={() => {
+          if (handleOnHideOverlay) {
+            return handleOnHideOverlay(this.onHideOverlay)
+          } else {
+            this.onHideOverlay()
+          }
+        }}
+        target={() => overlay.target}
       >
         <PopupComponent
           {...this.props}


### PR DESCRIPTION
This is because the show more popup is hiding before the drop event can finish, resulting in 'onDropEnd' to never be called by react beautiful d&d

I need a way to delay or prevent the overlay from hiding the popup until the drop event finishes... yes i tried upgrading calendar, no it didnt work, and it caused more issues. 

since we already have our own calendar build, figured id just stick with the current calendar version and just add this additional optional prop onto the month view.
